### PR TITLE
Update Cython vs Numba.ipynb

### DIFF
--- a/notebooks/Cython vs Numba.ipynb
+++ b/notebooks/Cython vs Numba.ipynb
@@ -56,9 +56,8 @@
    "outputs": [],
    "source": [
     "%%cython\n",
+    "@cython.infer_types(True)  # forces unsafe inference of possibly overflowing int types"
     "def cython_sum(int n):\n",
-    "    cdef double result\n",
-    "    cdef int i\n",
     "    result = 0\n",
     "    for i in range(n):\n",
     "        result += 1./(i+1)**2\n",


### PR DESCRIPTION
The primary difference in Numba vs. Cython here is that Cython refuses by default to infer fixed-size integer types for ints used in arithmetic (to avoid changing overflow behavior).
